### PR TITLE
Dex methods and fields count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,24 @@
 language: java
 sudo: false
-
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-
+  - "$HOME/.gradle/caches/"
+  - "$HOME/.gradle/wrapper/"
 deploy:
-  - provider: script
-    script: ./gradlew gitPublishPush
-    skip_cleanup: true
-    on:
-      tags: true
-
-  - provider: script
-    script: ./gradlew gitPublishPush
-    skip_cleanup: true
-    on:
-      branch: master
-
+- provider: script
+  script: "./gradlew gitPublishPush"
+  skip_cleanup: true
+  on:
+    tags: true
+- provider: script
+  script: "./gradlew gitPublishPush"
+  skip_cleanup: true
+  on:
+    branch: master
 notifications:
   email: false
   slack:
-    secure: qvapqTfI5kZEL6yagjLtrj2QvDl2RbSMFX3/WnM9BzzVYk7C1pvpUqdP+GYpGzG4I/hYnOXRnu93trlrV5Tr6zqWKUvSUe9SOoKFdE1WtmIl3/WVRj9LhQUB4jpfJOP0Gn9CqeH/QMFEyeWIxYE9sRTbNCS0fzz8VGznev0gPZGDnqJ7S5YwGdM4BFBxTsvAdrF/a031IEPTc0zjgBbWygLAupdGu5prz2h/TXzmYiKO6MfqzIsLKEUMHRtbSPZ7hiy9CEKUiaXPV+XAdN1txh4Z2VmFvm+RMjROL5lmQm06mwnVkks3Apft/9Wh22UvHvlWt6Pqjjx8fT6BTxYFjmx21DsIabew0FXW/RT3cxW0KnognJ/e7WL8iXB65e76xGN/WsYyLe0rOlV49KUNbNn+ig/kTYy8XcCPxWGiveE2V0Zn30hE9MLlznFUZztgIwUaaCP0oWcyXmKLn37wWOaTSD3WE78FccWM4Uf9TFOwzAMH6uCVjBFoVfwJpDCwpJzxIseOu+DTcY3QWStuPDkZSpjoab34pTVf7vsFo5Iqf1+1FMIeUxYV+h3B0Pu0l8aHgR8EKif+NMk4KvsFx6T31zo21I7sq/7B/Z1+4/Sq9EdGtLH7LpShEfvqmdz8MQxa6K4RYGj/GIqMoogrLre7qyJ2t93t+NBtPc5d8hU=
+    secure: QeuGw/5RPthMXX549Xacxyzz7mkau69LhySTUoRGTVZp2OJ0vpEiyJRoV/GPCs+UGsKrspjgS0Xyw69KCm5AjzsbzFxhY2rfiF8qezU8FASu5GtJogdMRnm6hh0XmxMNabb/4bN+qxjy3wb+zcJwp8B4wTvfMde/ZIlwX3GVmf0gcan924vi8einCJtLcI5sij+JlSkGNVlK2M/a8HO/MAlz17Y8/oSkLbtpkLv7nWI7zaIDyV4szikZb89xXJ9iChgauqPOUzL88DagVlwKOhyiW8ysStdc860vpTBaLQX0GNp+A+IL/c3o7gERFAJRfxJzEI7k82sRWNsrusF+lE3eyOfTqQkuebwTmEz8zww+HWPCnOBmaciC30rPr/z5JN4/53dX/9H36gi7C1KtdE6FBitnBzC9dDSlOpuMaEQR9s9nVufGplALaocFvZvn//8hh2vhvncvPkfWzWsY13p/+zqkxY8KG2OQQqjOXqs2SKIB829LbrlSZF2IEc1MFdRYvHRa7MGkcokY7FPu2vPUNBsx3GgWWzCZoQxVaCyZP9ZIzBCJd6eQetGbpWLH9TGETkWArgUF7gnI2Su1LCd+Cdq9hmAqjptUlCFspJ2LNaKBWINn+4Wx+Q2t9p+ZqIhKGmVoZRu6Ag6i1SHmopiHoi9M3TkqLvB4N7ZW5ag=

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ ext {
     IS_ANDROID = false
 
     API_COLLECTOR_VERSION = '1.4'
+    kotlin_version = '1.2.41'
 }
 
 apply plugin: "java-gradle-plugin"
@@ -46,9 +47,10 @@ dependencies {
     implementation "com.android.tools.build:gradle:3.1.2"
     implementation "org.ajoberstar:gradle-git-publish:0.3.3"
     implementation "digital.wup:android-maven-publish:3.3.0"
+    implementation "com.jakewharton.dex:dex-method-list:3.1.0"
 
-    implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+    implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "com.github.salomonbrys.kotson:kotson:2.5.0"
 
     testCompileOnly gradleTestKit()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,6 @@
 # Copyright 2018, Oath Inc.
 # Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 #
-
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/com/aol/mobile/sdk/apitracker/TrackerPlugin.kt
+++ b/src/main/kotlin/com/aol/mobile/sdk/apitracker/TrackerPlugin.kt
@@ -57,10 +57,10 @@ class TrackerPlugin : Plugin<Project> {
                 val version = ext.compareVersion
                 val groupPath = group.toString().replace(oldChar = '.', newChar = '/')
                 val publicManifestUrl = "https://raw.githubusercontent.com/aol-public/OneMobileSDK-releases-android/maven/" +
-                                "$groupPath/" +
-                                "$artifactId/" +
-                                "$version/" +
-                                "$artifactId-$version-pubapi.json"
+                        "$groupPath/" +
+                        "$artifactId/" +
+                        "$version/" +
+                        "$artifactId-$version-pubapi.json"
 
                 with(artifacts) {
                     add("archives", manifestFile) { artifact ->

--- a/src/main/kotlin/com/aol/mobile/sdk/cilib/task/DexMetricsTask.kt
+++ b/src/main/kotlin/com/aol/mobile/sdk/cilib/task/DexMetricsTask.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018, Oath Inc.
+ * Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+ */
+
+package com.aol.mobile.sdk.cilib.task
+
+import com.jakewharton.dex.DexParser
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+import java.io.File
+
+open class DexMetricsTask : DefaultTask() {
+    @InputFile
+    lateinit var aarFile: File
+    @OutputFile
+    lateinit var metricsReportFile: File
+
+    @TaskAction
+    fun measureAar(inputs: IncrementalTaskInputs) {
+        if (inputs.isIncremental)
+            project.delete(metricsReportFile)
+
+        inputs.outOfDate { change ->
+            val aarFile = change.file
+            val parser = DexParser.fromFile(aarFile)
+            val methodsCount = parser.listMethods().size
+            val fieldsCount = parser.listFields().size
+
+            metricsReportFile.writeText("# Methods count: $methodsCount Fields count: $fieldsCount")
+        }
+
+        inputs.removed {
+            if (metricsReportFile.exists()) project.delete(metricsReportFile)
+        }
+    }
+}


### PR DESCRIPTION
## Plugin extension that helps track dex limitation

PR contains new tasks that will generate markdown files to `${rootProject.buildDir}/maven/DEX COUNT` with total amount of fields and methods. Also removed filtering for release only variants, cuz it was preventing **AS** from recognizing instrumental tests. Also added runner for such instrumental tests. 

We will have to release this ASAP.

@OlegKozhemiakin Please, review