### PR TITLE
Add check for proguard files

### DIFF
--- a/src/main/kotlin/com/aol/mobile/sdk/cilib/AndroidCiLibrary.kt
+++ b/src/main/kotlin/com/aol/mobile/sdk/cilib/AndroidCiLibrary.kt
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.JavadocOfflineLink
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import java.io.File
+import java.io.FileNotFoundException
 
 class AndroidCiLibrary : Plugin<Project> {
     companion object {
@@ -155,7 +156,11 @@ class AndroidCiLibrary : Plugin<Project> {
                             val apiProguardFile = file("$artifactDir/proguard-classes-$buildTypeName.pro")
 
                             buildType.apply {
-                                consumerProguardFiles(apiProguardFile)
+                                if (apiProguardFile.exists()) {
+                                    consumerProguardFiles(apiProguardFile)
+                                } else {
+                                    throw FileNotFoundException("$apiProguardFile Doesn't exists!")
+                                }
                             }
                         } else {
                             productFlavors.all { flavor ->
@@ -163,7 +168,11 @@ class AndroidCiLibrary : Plugin<Project> {
                                     val flavorName = name.toLowerCase()
                                     val flavoredProguardFile = file("$artifactDir/proguard-classes-$flavorName$buildTypeName.pro")
 
-                                    consumerProguardFile(flavoredProguardFile)
+                                    if (flavoredProguardFile.exists()) {
+                                        consumerProguardFile(flavoredProguardFile)
+                                    } else {
+                                        throw FileNotFoundException("$flavoredProguardFile Doesn't exists!")
+                                    }
                                 }
                             }
                         }

--- a/src/main/kotlin/com/aol/mobile/sdk/cilib/AndroidCiLibrary.kt
+++ b/src/main/kotlin/com/aol/mobile/sdk/cilib/AndroidCiLibrary.kt
@@ -159,7 +159,7 @@ class AndroidCiLibrary : Plugin<Project> {
                                 if (apiProguardFile.exists()) {
                                     consumerProguardFiles(apiProguardFile)
                                 } else {
-                                    throw FileNotFoundException("$apiProguardFile Doesn't exists!")
+                                    throw FileNotFoundException("$apiProguardFile Doesn't exist!")
                                 }
                             }
                         } else {
@@ -171,7 +171,7 @@ class AndroidCiLibrary : Plugin<Project> {
                                     if (flavoredProguardFile.exists()) {
                                         consumerProguardFile(flavoredProguardFile)
                                     } else {
-                                        throw FileNotFoundException("$flavoredProguardFile Doesn't exists!")
+                                        throw FileNotFoundException("$flavoredProguardFile Doesn't exist!")
                                     }
                                 }
                             }


### PR DESCRIPTION
I conducted research in order to find out the problem of the absence of proguard.txt file in the .aar. It turned out that at the configuration stage ProGuard files don't exist and in order to fix this problem we should build the project twice - ./gradlew assemble && ./gradle build.